### PR TITLE
Use the add syntax for adding the compileScrooge tasks.

### DIFF
--- a/src/main/groovy/org/iamsteveholmes/gradle/ScroogePlugin.groovy
+++ b/src/main/groovy/org/iamsteveholmes/gradle/ScroogePlugin.groovy
@@ -7,7 +7,7 @@ class ScroogePlugin implements Plugin<Project> {
 
     @Override
     void apply(final Project project) {
-        project.task(type: org.iamsteveholmes.gradle.ScroogeCompileTask, "compileScrooge")
+        project.tasks.add("compileScrooge", org.iamsteveholmes.gradle.ScroogeCompileTask)
 
         project.afterEvaluate {
             project.tasks.compileScrooge.execute()


### PR DESCRIPTION
The groovy interpreter in gradle 1.9 was trying to look for
a property of ScroogePlugin called "org", which is wasn't finding.

The tests as modified work going back to gradle 1.4.
